### PR TITLE
Shows unused Menu on Devices with Hardware-Menu-Button

### DIFF
--- a/app/TheListApp/app/src/main/java/org/creativecommons/thelist/activities/StartActivity.java
+++ b/app/TheListApp/app/src/main/java/org/creativecommons/thelist/activities/StartActivity.java
@@ -283,24 +283,4 @@ public class StartActivity extends FragmentActivity implements ExplainerFragment
                 .commit();
         mFrameLayout.setClickable(false);
     }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.menu_start, menu);
-        return true;
-    } //onCreateOptionsMenu
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.action_done) {
-            return true;
-        }
-        return super.onOptionsItemSelected(item);
-    } //onOptionsItemSelected
 } //StartActivity


### PR DESCRIPTION
An unused Settings menu item is shown, when I press the Hardware-Menu-Button of my Galaxy S3.